### PR TITLE
Fixes the special forces path for Canada, a path nobody will ever play so it doesn't really matter, but still.

### DIFF
--- a/common/national_focus/canada.txt
+++ b/common/national_focus/canada.txt
@@ -1348,14 +1348,13 @@ focus_tree = {
 
 		completion_reward = {
 			add_tech_bonus = {
-				name = CAN_Marine
-				bonus = 1
+				name = CAN_marines
+				bonus = 1.0
 				uses = 2
-				category = marine_tech
+				category = cat_special_forces_generic
 			}
-			add_tech_bonus = {
-				name = CAN_Doctrine
-				bonus = 0.5
+			add_doctrine_cost_reduction = {
+				cost_reduction = 0.5
 				uses = 4
 				category = special_forces_doctrine
 			}


### PR DESCRIPTION
Changes the 2x100% marines bonus to 2x100% special forces bonus, because nobody is using the 100% on the second marine tech, that's just a troll for people who can't read. Fixes the doctrine cost reduction for special forces doctrine, kept the value exactly as it was (no balance change).

Nobody will ever pick this path anyway so it doesn't matter.