### PR TITLE
Slight Hungarian IC Buff

### DIFF
--- a/common/characters/HUN.txt
+++ b/common/characters/HUN.txt
@@ -690,14 +690,14 @@ characters = {
 				}
 
 				available = {
-					has_completed_focus = wuw_HUN_make_the_magyar_legiero_known
+					has_completed_focus = wuw_HUN_allied_manufacturing_programs
 				}
 
 				traits = {
-					air_chief_ground_support_2
+					air_chief_ground_support_3
 				}
 
-				cost = 100
+				cost = 200
 
 				ai_will_do = {
 					base = 1
@@ -1345,12 +1345,12 @@ characters = {
 
 			# Can become a general through the military promotions focus
 			corps_commander = {
-				traits = { hill_fighter }
-				skill = 3
-				attack_skill = 2
-				defense_skill = 3
-				planning_skill = 2
-				logistics_skill = 3
+				traits = { hill_fighter trait_engineer infantry_leader commando}
+				skill = 4
+				attack_skill = 3
+				defense_skill = 4
+				planning_skill = 3
+				logistics_skill = 4
 				legacy_id = -1
 				visible = {
 					has_completed_focus = wuw_HUN_award_military_promotions
@@ -1706,14 +1706,11 @@ characters = {
 				}
 
 				available = {
-					OR = {
-						has_completed_focus = wuw_HUN_undercover_air_maneuvers
-						wuw_HUN_does_not_have_trianon = yes
-					}
+					wuw_HUN_does_not_have_trianon = yes
 				}
 
 				traits = {
-					air_air_combat_training_2
+					air_air_superiority_3
 				}
 
 				cost =  100

--- a/common/characters/HUN.txt
+++ b/common/characters/HUN.txt
@@ -1710,7 +1710,7 @@ characters = {
 				}
 
 				traits = {
-					air_air_superiority_3
+					air_air_superiority_2
 				}
 
 				cost =  100

--- a/common/ideas/hungary.txt
+++ b/common/ideas/hungary.txt
@@ -19,10 +19,10 @@ ideas = {
 					build_cost_ic = -0.15 instant = yes
 				}
 				artillery_equipment = {
-					build_cost_ic = -0.1 instant = yes
+					build_cost_ic = -0.15 instant = yes
 				}
 				rocket_artillery_equipment = {
-					build_cost_ic = -0.1 instant = yes
+					build_cost_ic = -0.15 instant = yes
 				}
 				
 			}
@@ -2088,7 +2088,7 @@ ideas = {
 				production_speed_industrial_complex_factor = 0.15
 				production_speed_supply_node_factor = 0.15
 				production_speed_rail_way_factor = 0.1
-				research_speed_factor = 0.15
+				research_speed_factor = 0.2
 			}
 		}
 

--- a/common/national_focus/hungary_wuw.txt
+++ b/common/national_focus/hungary_wuw.txt
@@ -3224,15 +3224,6 @@ focus_tree = {
 
 			custom_effect_tooltip = generic_skip_one_line_tt
 
-			add_tech_bonus = {
-				name = wuw_HUN_carpathian_mountaineers
-				bonus = 1
-				uses = 1
-				category = mountaineers_tech
-			}
-
-			custom_effect_tooltip = generic_skip_one_line_tt
-
 			IF = {
 				limit = {
 					NOT = {
@@ -3241,6 +3232,15 @@ focus_tree = {
 				}
 				custom_effect_tooltip = ROM_mountain_artillery_tech_tt
 				hidden_effect = { set_technology = { mountain_gun = 1 } }
+			}
+
+			custom_effect_tooltip = generic_skip_one_line_tt
+
+			add_tech_bonus = {
+				name = wuw_HUN_carpathian_mountaineers
+				bonus = 1
+				uses = 1
+				category = mountaineers_tech
 			}
 			
 		}

--- a/common/national_focus/hungary_wuw.txt
+++ b/common/national_focus/hungary_wuw.txt
@@ -1578,7 +1578,7 @@ focus_tree = {
 
 			add_tech_bonus = {
 				name = HUN_industrial_revitalization
-				bonus = 0.75
+				bonus = 1
 				uses = 1
 				category = industry
 			}
@@ -1809,10 +1809,10 @@ focus_tree = {
 					}
 				}
 				43 = {
-					add_extra_state_shared_building_slots = 1
+					add_extra_state_shared_building_slots = 2
 					add_building_construction = {
 						type = industrial_complex
-						level = 1
+						level = 2
 						instant_build = yes
 					}
 				}
@@ -2584,7 +2584,7 @@ focus_tree = {
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
 					type = arms_factory
-					level = 1
+					level = 2
 					instant_build = yes
 				}
 			}
@@ -2816,59 +2816,6 @@ focus_tree = {
 				type = support_equipment
 				amount = 1000
 				producer = ROOT
-			}
-
-			custom_effect_tooltip = generic_skip_one_line_tt
-
-			custom_effect_tooltip = wuw_HUN_szent_laszlo_infantry_division_tt
-
-			hidden_effect = {
-				delete_unit_template_and_units = {
-					division_template = "Szent László Hadosztály"
-					disband = yes #if yes, will refund equipment/manpower.
-				}
-
-				division_template = {
-					name = "Szent László Hadosztály"
-					division_names_group = HUN_INF_01
-					role = infantry
-					is_locked = no
-					regiments = {
-						infantry = { x = 0 y = 0 }
-						infantry = { x = 0 y = 1 }
-						infantry = { x = 0 y = 2 }
-						infantry = { x = 1 y = 0 }
-						infantry = { x = 1 y = 1 }
-						infantry = { x = 1 y = 2 }
-						artillery_brigade = { x = 2 y = 0 }
-					}
-					support = {
-						recon = { x = 0 y = 0 }
-						engineer = { x = 0 y = 1 }
-						artillery = { x = 0 y = 2 }
-					}
-				}
-
-				random_state = {
-					limit = {
-						is_fully_controlled_by = ROOT
-						is_owned_by = ROOT
-						is_core_of = ROOT
-					}
-					create_unit = {
-					    division = "name = \"Szent László Hadosztály\" division_template = \"Szent László Hadosztály\" start_experience_factor = 0.6 start_equipment_factor = 1"
-					    owner = ROOT
-					    officer = {
-					    	name = HUN_zoltan_zsugyi
-					    	portraits = {
-					    		army = {
-					    			large = GFX_portrait_HUN_zoltan_szugyi
-					    			small = GFX_portrait_HUN_zoltan_szugyi_small
-					    		}
-					    	}
-					    }
-					}
-				}
 			}
 
 		}
@@ -3201,7 +3148,7 @@ focus_tree = {
 		available_if_capitulated = no
 
 		completion_reward = {
-			custom_effect_tooltip = available_political_advisor
+			custom_effect_tooltip = available_military_high_command
 			show_ideas_tooltip = ROM_gheorghe_mihail
 			
 			custom_effect_tooltip = generic_skip_one_line_tt
@@ -3418,6 +3365,8 @@ focus_tree = {
 	available_if_capitulated = no
 
 	completion_reward = {
+		custom_effect_tooltip = available_chief_of_airforce
+		show_ideas_tooltip = HUN_ferenc_feketehalmyczeydner
 		if = {
 			limit = {
 				has_dlc = "By Blood Alone"

--- a/localisation/english/WUW_focus_l_english.yml
+++ b/localisation/english/WUW_focus_l_english.yml
@@ -129,7 +129,7 @@
  HUN_solyom_development: "Development of the Weiss WM-21 Sólyom"
  HUN_laszlo_varga_design: "Developed Laszlo Vargas design"
  wuw_HUN_allied_manufacturing_programs_tt: "Our Faction Leader will gain 2 §YOffmap Civilian Factories§! and §Y1x§! §G50%§! research speed bonus to §YAir Equipment§!"
- HUN_ferenc_szombathelyi_becomes_a_general: "§YFerenc Szombathelyi§! becomes available as a level 3 §YGeneral§!"
+ HUN_ferenc_szombathelyi_becomes_a_general: "§YFerenc Szombathelyi§! becomes available as a level 4 §YGeneral§!"
  wuw_HUN_the_szekel_command_division_tt: "Gain two units with 4 §YMountaineer§! battalions and 1 §YArtillery§! battalion"
  HUN_sich_riflemen_infantry_recruitment: "Gain three units with 9 §YInfantry§! battalions"
  HUN_joseph_august_von_habsburg_becomes_available_as_field_marshal_tt: "§YJoseph August von Habsburg§! becomes available as a level 3 §YField Marshal§!"


### PR DESCRIPTION


To be merged when the poll finishes

- Added Infantry Pregrinds to Ferenc Szombathelyi, unlocked under focous Award Military Promotions
- Air Training Expert Changed to Air Superiority Expert
- Added Infantry Pregrinds to Ferenc Szombathelyi, unlocked under focous Award Military Promotions
AC Hungary revival???

- Promote Increased Urbanization: 1 Civ -> 2 Civs
- Establish the Mavag Army Division: 1 Mil -> 2 Mils
- Invite Foreign Investors Research Speed Buffed: 15% -> 20%
- The Botond :
    - Towed Artillery Production Cost Buffed : -10% -> -15%
    - Rocket Artillery Production Cost Buffed : -10% -> -15%
