### PR TITLE
Fixes the spawn-ins for Norway and Denmark so they don't spawn-again when Vichy declares on them

### DIFF
--- a/common/on_actions/hmm_on_actions.txt
+++ b/common/on_actions/hmm_on_actions.txt
@@ -495,6 +495,7 @@ on_actions = {
                     FROM = {
                         tag = DEN
                     }
+					date < 1940.8.31
                 }
                 DEN = {
                     load_oob = "DEN_CHROM_SPAWN"
@@ -527,6 +528,7 @@ on_actions = {
                     FROM = {
                         tag = NOR
                     }
+					date < 1940.8.31
                 }
                 NOR = {
                     load_oob = "NOR_CHROM_SPAWN"


### PR DESCRIPTION
I'm not altogether sure what causes Vichy to declare on them, but this will fix the issue. If the axis declares on them after august 1940, they will no longer spawn in. Tough luck for the allies, I guess.